### PR TITLE
El-Get compatible mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,25 +28,44 @@ Then, place a file named `Cask` in the directory where your emacs init
 file is located.  The contents of the file is Cask [DSL][].
 
 Next time you run your Emacs, packages defined in `Cask` file are
-installed. You can also use [El-Get][] commands such as
+installed.  You can also use [El-Get][] commands such as
 `el-get-install` or `el-get-update` as usual.
 
-All the packages are installed in `.el-get-cask` directory under the
-same directory where `Cask` file is located.  `el-get-dir` variable is
-overridden to this directory to make [El-Get][] work.  In this case,
-packages maintained by `package.el` are installed in
-`.el-get-cask/elpa` and `package-user-dir` variable is overriden to
-this directory.
+## Directory to install
 
-## [El-Get][] Compatible Mode
+If you are not using [El-Get][] directly, all the packages are
+installed in `.el-get-cask` directory under the same directory where
+`Cask` file is located.  `el-get-dir` variable is overridden to this
+directory to make [El-Get][] work.  In this case, packages maintained
+by `package.el` are installed in `.el-get-cask/elpa` and
+`package-user-dir` variable is overriden to this directory.
 
-If you have [El-Get][] installed and required before `el-get-cask` is
-loaded, then `el-get-cask` works as [El-Get][] compatible mode.  In
-this mode, no directory overriding for `el-get-dir` and
-`package-user-dir` happen, and, the default source type is not
-restricted to `elpa` in `depends-on` notation, i.e., the source type
-is taken from an [El-Get][] recipe unless you explicitly specify it by
-a `:type` property or a `TYPE:` modifier.
+Otherwise, if you have [El-Get][] installed before loading
+`el-get-cask`, then the directory settings of [El-Get][] and
+`package.el` are used (they are `~/.emcas.d/el-get` and
+`~/.emacs.d/elpa` by default).
+
+## Using [El-Get][] sources
+
+In addition to the `package.el` sources, [El-Get][] sources (recipes)
+can be added by `source` DSL command as the following code.
+
+```elisp
+(source el-get)
+```
+
+If you add [El-Get][] sources, `depends-on` command installs a package
+from an [El-Get][] source if available.  When there is no package
+vailable in [El-Get][] recipes, `depends-on` falls back to a
+`package.el` source.
+
+## Extended notation
+
+With `el-get-cask`, `depends-on` is just a syntactic sugar for
+`el-get-bundle`.  All notation for `el-get-bundle` including package
+name modifiers and an initialization form are available for
+`depends-on` command.  See the documentation of `el-get-bundle` for
+the detail.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -28,27 +28,25 @@ Then, place a file named `Cask` in the directory where your emacs init
 file is located.  The contents of the file is Cask [DSL][].
 
 Next time you run your Emacs, packages defined in `Cask` file are
-installed.
+installed. You can also use [El-Get][] commands such as
+`el-get-install` or `el-get-update` as usual.
 
-## [El-Get][] integration
+All the packages are installed in `.el-get-cask` directory under the
+same directory where `Cask` file is located.  `el-get-dir` variable is
+overridden to this directory to make [El-Get][] work.  In this case,
+packages maintained by `package.el` are installed in
+`.el-get-cask/elpa` and `package-user-dir` variable is overriden to
+this directory.
 
-If you want to use commands from [El-Get][], then you will need some
-more configuration.  Write the following code after
-`(el-get-cask-load)` in your emacs init file.
+## [El-Get][] Compatible Mode
 
-```lisp
-(setq el-get-dir (expand-file-name ".el-get-cask" user-emacs-directory)
-      package-user-dir (expand-file-name "elpa" el-get-dir))
-```
-
-This overrides the global configuration for `el-get.el` and
-`package.el`.  Do this only if you won't use them without
-`el-get-cask`.
-
-Instead of doing this, consider translating `depends-on` in `Cask`
-file into `el-get-bundle` in your Emacs init file and use [El-Get][]
-without `el-get-cask`.  This is a better way to manage your packages
-without harm.
+If you have [El-Get][] installed and required before `el-get-cask` is
+loaded, then `el-get-cask` works as [El-Get][] compatible mode.  In
+this mode, no directory overriding for `el-get-dir` and
+`package-user-dir` happen, and, the default source type is not
+restricted to `elpa` in `depends-on` notation, i.e., the source type
+is taken from an [El-Get][] recipe unless you explicitly specify it by
+a `:type` property or a `TYPE:` modifier.
 
 ## Limitations
 

--- a/el-get-cask.el
+++ b/el-get-cask.el
@@ -95,8 +95,10 @@
   (let* ((file (or file el-get-cask-default-cask-file))
          (file (expand-file-name file))
          (base-dir (file-name-directory file))
-         (el-get-dir (expand-file-name el-get-cask-dir base-dir))
-         (package-user-dir (expand-file-name "elpa" el-get-dir)))
+         (el-get-installed (bound-and-true-p el-get-dir)))
+    (unless el-get-installed
+      (setq el-get-dir (expand-file-name el-get-cask-dir base-dir)
+            package-user-dir (expand-file-name "elpa" el-get-dir)))
     (el-get-cask--require-el-get el-get-dir)
     (el-get-cask-with-dsl (source depends-on
                            files package package-file development)

--- a/el-get-cask.el
+++ b/el-get-cask.el
@@ -106,12 +106,13 @@
   (let* ((file (or file el-get-cask-default-cask-file))
          (file (expand-file-name file))
          (base-dir (file-name-directory file))
+         (el-get-installed (require 'el-get nil t))
          (el-get-cask-compatible-mode nil)
          (el-get-cask-sources nil))
     (el-get-cask-with-dsl (source depends-on
                            files package package-file development)
       (load file)
-      (unless el-get-cask-compatible-mode
+      (unless el-get-installed
         (setq el-get-dir (expand-file-name el-get-cask-dir base-dir)
               package-user-dir (expand-file-name "elpa" el-get-dir)))
       (el-get-cask--require-el-get)

--- a/el-get-cask.el
+++ b/el-get-cask.el
@@ -140,7 +140,7 @@
   "Add a dependency."
   (declare (indent 1) (debug 1))
   (let* ((name (if (stringp name) (intern name)
-                 (or (and (listp package) (nth 1 package)) package))))
+                 (or (and (listp name) (nth 1 name)) name))))
     `(add-to-list 'el-get-cask-packages '(,name ,@args) t)))
 
 ;;;###autoload

--- a/el-get-cask.el
+++ b/el-get-cask.el
@@ -53,7 +53,7 @@
 
 (defvar el-get-cask-sources nil)
 (defvar el-get-cask-packages nil)
-(defvar el-get-cask-compatible-mode nil)
+(defvar el-get-cask-el-get-source nil)
 
 (defun el-get-cask--require-el-get ()
   (let ((el-get-dir (or (bound-and-true-p el-get-dir)
@@ -80,7 +80,7 @@
     (let* ((package (symbol-name name))
            (source (append (el-get-bundle-parse-name name)
                            props
-                           (and el-get-cask-compatible-mode
+                           (and el-get-cask-el-get-source
                                 (ignore-errors (el-get-package-def package))))))
       (unless (plist-get source :type)
         (setq source (list* :type (el-get-bundle-guess-type source) source)))
@@ -107,7 +107,7 @@
          (file (expand-file-name file))
          (base-dir (file-name-directory file))
          (el-get-installed (require 'el-get nil t))
-         (el-get-cask-compatible-mode nil)
+         (el-get-cask-el-get-source nil)
          (el-get-cask-sources nil))
     (el-get-cask-with-dsl (source depends-on
                            files package package-file development)
@@ -128,7 +128,7 @@
   "Add a package mirror named NAME-OR-ALIAS."
   (when (stringp name-or-alias) (setq (intern name-or-alias)))
   (when (listp name-or-alias) (setq (name-or-alias (nth 1 name-or-alias))))
-  (when (eq name-or-alias 'el-get) (setq el-get-cask-compatible-mode t))
+  (when (eq name-or-alias 'el-get) (setq el-get-cask-el-get-source t))
   `(let ((name ',name-or-alias) (url ',url))
      (let ((pair (assq name el-get-cask-source-alist)))
        (when (and (not url) pair)

--- a/el-get-cask.el
+++ b/el-get-cask.el
@@ -118,12 +118,13 @@
 ;;;###autoload
 (defmacro el-get-cask-source (name-or-alias &optional url)
   "Add a package mirror named NAME-OR-ALIAS."
-  (let ((pair (assq name-or-alias el-get-cask-source-alist)))
-    (when (and (not url) pair)
-      (setq name-or-alias (symbol-name (car pair))
-            url (cdr pair)))
-    `(when (and ,name-or-alias ,url)
-       (add-to-list 'el-get-cask-sources (cons ,name-or-alias ,url) t))))
+  (if (and (symbolp name-or-alias) (eq name-or-alias 'el-get))
+      (setq el-get-cask-default-type nil)
+    (let ((pair (assq name-or-alias el-get-cask-source-alist)))
+      (when (and (not url) pair)
+        (setq name-or-alias (symbol-name (car pair))
+              url (cdr pair)))
+      `(add-to-list 'el-get-cask-sources (cons ',name-or-alias ',url) t))))
 
 ;;;###autoload
 (defmacro el-get-cask-depends-on (name &rest args)
@@ -132,7 +133,6 @@
   (let ((name (if (stringp name) (intern name)
            (or (and (listp package) (nth 1 package)) package)))
         (args (el-get-cask--args args)))
-    (print (list name args))
     `(add-to-list 'el-get-cask-packages '(,name ,@args) t)))
 
 ;;;###autoload


### PR DESCRIPTION
### TODO
- [x] Option to use the default directory for `el-get` and `elpa`
- [x] `(source el-get)`
- [x] `elpa` dependencies are poorly supported?
  - Dependent packages are not added to the load path.  Maybe we need to add `depends` for `elpa` packages.
